### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.2
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Mon Nov 05 2018 Liz Nemsick <lnemsick-simp@gmail.com> - 1.0.1
 - Update to Hiera 5
 

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ This module is compatible with GDM v2, v3.
 
 ## Development
 
-Please read our [Contribution Guide] (http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html)
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-mate",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "SIMP Team",
   "summary": "Provides useful settings to set up the MATE desktop environment",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-mate