### PR TITLE
(SIMP-10046) mate Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,11 @@
 ---
 fixtures:
   repositories:
-    concat:               "https://github.com/simp/puppetlabs-concat"
-    dconf:                "https://github.com/simp/pupmod-simp-dconf"
-    inifile:              "https://github.com/simp/puppetlabs-inifile"
-    polkit:               "https://github.com/simp/pupmod-simp-polkit"
-    simplib:              "https://github.com/simp/pupmod-simp-simplib"
-    stdlib:               "https://github.com/simp/puppetlabs-stdlib"
+    concat: https://github.com/simp/puppetlabs-concat.git
+    dconf: https://github.com/simp/pupmod-simp-dconf.git
+    inifile: https://github.com/simp/puppetlabs-inifile.git
+    polkit: https://github.com/simp/pupmod-simp-polkit.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
   symlinks:
     mate: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,3 +368,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,6 +23,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Made sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URLs
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-mate acceptance tests configured
SIMP-10046 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666